### PR TITLE
Use correct arch specifier for Linux/aarch64 com.fluree/crypto

### DIFF
--- a/manifests/com.fluree/crypto/0.1.0/manifest.edn
+++ b/manifests/com.fluree/crypto/0.1.0/manifest.edn
@@ -8,7 +8,7 @@
    :artifact/url "https://github.com/fluree/pod-fluree-crypto/releases/download/v0.1.0/pod-fluree-crypto-linux-amd64.zip"
    :artifact/executable "pod-fluree-crypto"}
   {:os/name "Linux.*"
-   :os/arch "arm64"
+   :os/arch "aarch64"
    :artifact/url "https://github.com/fluree/pod-fluree-crypto/releases/download/v0.1.0/pod-fluree-crypto-linux-arm64.zip"
    :artifact/executable "pod-fluree-crypto"}
   {:os/name "Mac.*"


### PR DESCRIPTION
Oops. Noticed it wasn't finding this one when I actually tried to install it.