### PR TITLE
Update com.fluree/crypto to v0.1.2

### DIFF
--- a/manifests/com.fluree/crypto/0.1.2/manifest.edn
+++ b/manifests/com.fluree/crypto/0.1.2/manifest.edn
@@ -1,0 +1,17 @@
+{:pod/name com.fluree/crypto
+ :pod/description "Fluree crypto library"
+ :pod/version "0.1.2"
+ :pod/license "MIT"
+ :pod/artifacts
+ [{:os/name "Linux.*"
+   :os/arch "amd64"
+   :artifact/url "https://github.com/fluree/pod-fluree-crypto/releases/download/v0.1.2/pod-fluree-crypto-linux-amd64.zip"
+   :artifact/executable "pod-fluree-crypto"}
+  {:os/name "Linux.*"
+   :os/arch "aarch64"
+   :artifact/url "https://github.com/fluree/pod-fluree-crypto/releases/download/v0.1.2/pod-fluree-crypto-linux-arm64.zip"
+   :artifact/executable "pod-fluree-crypto"}
+  {:os/name "Mac.*"
+   :os/arch "amd64"
+   :artifact/url "https://github.com/fluree/pod-fluree-crypto/releases/download/v0.1.2/pod-fluree-crypto-macos-amd64.zip"
+   :artifact/executable "pod-fluree-crypto"}]}


### PR DESCRIPTION
...which should be live in our GitHub repo shortly (CD action is building now and the linux/arm64 build takes _forever_ under qemu).

I used the `upgrade-manifest.clj` script this time! :)