### PR TITLE
Update lanterna to non SNAPSHOT release

### DIFF
--- a/manifests/org.babashka/lanterna/0.0.1-SNAPSHOT/manifest.edn
+++ b/manifests/org.babashka/lanterna/0.0.1-SNAPSHOT/manifest.edn
@@ -3,7 +3,7 @@
  :pod/version "0.0.1-SNAPSHOT"
  :pod/license ""
  :pod/options {:transport :socket}
- :pod/example "examples/laterna.clj"
+ :pod/example "examples/lanterna.clj"
  :pod/language "clojure"
  :pod/artifacts
  [{:os/name "Mac.*"

--- a/manifests/org.babashka/lanterna/0.0.1/manifest.edn
+++ b/manifests/org.babashka/lanterna/0.0.1/manifest.edn
@@ -1,0 +1,16 @@
+{:pod/name org.babashka/lanterna
+ :pod/description "A Clojurey wrapper around the Lanterna terminal output library."
+ :pod/version "0.0.1"
+ :pod/license ""
+ :pod/options {:transport :socket}
+ :pod/example "examples/lanterna.clj"
+ :pod/language "clojure"
+ :pod/artifacts
+ [{:os/name "Mac.*"
+   :os/arch "x86_64"
+   :artifact/url "https://github.com/babashka/pod-babashka-lanterna/releases/download/v0.0.1/pod-babashka-lanterna-0.0.1-macos-amd64.zip"
+   :artifact/executable "pod-babashka-lanterna"}
+  {:os/name "Linux.*"
+   :os/arch "amd64"
+   :artifact/url "https://github.com/babashka/pod-babashka-lanterna/releases/download/v0.0.1/pod-babashka-lanterna-0.0.1-linux-amd64.zip"
+   :artifact/executable "pod-babashka-lanterna"}]}


### PR DESCRIPTION
Just adding the updated manifest for the new `0.0.1`, non SNAPSHOT, release of [pod-babashka-lanterna](https://github.com/babashka/pod-babashka-lanterna/releases/tag/v0.0.1).

I couldn't find any other examples of a SNAPSHOT release in the repo. Do I need to blow away the `0.0.1-SNAPSHOT` folder? If the folder structure is being used to determine the latest release using "alphabetical" order of the subfolders, I suspect this one might throw a wrench in the gears, but I'm not certain.
