### PR TITLE
com.github.jackdbd/jsoup 0.4.0

### DIFF
--- a/examples/jsoup.bb
+++ b/examples/jsoup.bb
@@ -1,0 +1,16 @@
+#!/usr/bin/env bb
+
+(require '[babashka.http-client :as http])
+(require '[babashka.pods :as pods])
+
+(pods/load-pod 'com.github.jackdbd/jsoup "0.4.0")
+
+(require '[pod.jackdbd.jsoup :as jsoup])
+
+(def text (-> (http/get "https://clojure.org")
+              :body
+              (jsoup/select "div p")
+              first
+              :text))
+
+(println text)

--- a/manifests/com.github.jackdbd/jsoup/0.4.0/manifest.edn
+++ b/manifests/com.github.jackdbd/jsoup/0.4.0/manifest.edn
@@ -1,0 +1,19 @@
+{:pod/name com.github.jackdbd/pod.jackdbd.jsoup
+ :pod/description "Babashka pod for parsing HTML with jsoup."
+ :pod/example "examples/jsoup.bb"
+ :pod/language "clojure"
+ :pod/license "MIT"
+ :pod/version "0.4.0"
+ :pod/artifacts
+ [{:os/arch "amd64"
+   :os/name "Linux.*"
+   :artifact/url "https://github.com/jackdbd/pod-jackdbd-jsoup/releases/download/v0.4.0/pod-jackdbd-jsoup-0.4.0-ubuntu-latest-amd64.zip"
+   :artifact/executable "com-github-jackdbd/pod-jackdbd-jsoup"}
+  {:os/arch "aarch64"
+   :os/name "Mac.*"
+   :artifact/url "https://github.com/jackdbd/pod-jackdbd-jsoup/releases/download/v0.4.0/pod-jackdbd-jsoup-0.4.0-macos-latest-aarch64.zip"
+   :artifact/executable "com-github-jackdbd/pod-jackdbd-jsoup"}
+  {:os/arch "amd64"
+   :os/name "Windows.*"
+   :artifact/url "https://github.com/jackdbd/pod-jackdbd-jsoup/releases/download/v0.4.0/pod-jackdbd-jsoup-0.4.0-windows-latest-amd64.zip"
+   :artifact/executable "com-github-jackdbd/pod-jackdbd-jsoup.exe"}]}


### PR DESCRIPTION
I tried using [pod-jaydeesimon-jsoup](https://github.com/jaydeesimon/pod-jaydeesimon-jsoup) on my NixOS laptop but it didn't work because the pod binary is dynamically linked.

I wanted to use `deps.edn` and make a few other minor changes to the code, so I started from scratch instead of opening a PR on that project.

I compiled a statically linked Linux binary with GraalVM native-image and musl.

I also added an example.

All artifacts are [hosted here GitHub Releases](https://github.com/jackdbd/pod-jackdbd-jsoup/releases).

🤔 Should I also include the uberjar in the `manifest.edn`?
